### PR TITLE
debug: adding verbosity to grow function

### DIFF
--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -169,8 +169,6 @@ int reapi_cli_t::grow (void *h,
                        const std::string &R_subgraph)
 {
     resource_query_t *rq = static_cast<resource_query_t *> (h);
-    int rc = -1;
-
     return rq->grow (std::string (R_subgraph));
 }
 
@@ -746,9 +744,12 @@ int resource_query_t::grow (const std::string &R_subgraph)
         m_err_msg += ": ERROR: can't create JGF reader\n";
         return rc;
     }
-
-
-    return reader->unpack_at (db->resource_graph, db->metadata, v, R_subgraph, -1);
+    rc = reader->unpack_at (db->resource_graph, db->metadata, v, R_subgraph, -1);
+    if (rc != 0) {
+        m_err_msg = __FUNCTION__;
+        m_err_msg += ": ERROR: grow reader unpack_at\n";
+    }
+    return rc;
 }
 
 void resource_query_t::incr_job_counter ()


### PR DESCRIPTION
This is a small tweak to the grow function in the c reapi only to make it clear that we make it to the end. From my commit:

> We need to figure out why the function is returning -1. I am adding an additional error parsing to check.

I also see a return code "rc" defined that I don't think we used. For grow, I don't see any error messages except for:

```console
Error in ReapiClient Grow: issue resource api client grow -1 grow: ERROR: grow reader unpack_at
```

But I do see that we are setting `m_err_msg` in the reader. The only thing I see is that instead of `+=` to the variable we do an `=`.  So probably we first need to figure out why we don't see those messages, and that will give insight to the error. I'm guessing this is user error with how I've defined the jgf - I tried to start with tiny.json and then make a second jgf to extend it to add two more nodes, and likely did something wrong. Regardless, it will be fun to work on this for a Hackathon next week. 