### PR TITLE
debug: resource api messages

### DIFF
--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -1298,10 +1298,7 @@ int resource_reader_jgf_t::unpack_at (resource_graph_t &g,
                                       const std::string &str,
                                       int rank)
 {
-    /* This functionality is currently experimental, as resource graph
-     * growth causes a resize of the boost vecS vertex container type.
-     * Resizing the vecS results in lost job allocations and reservations
-     * as there is no copy constructor for planner.
+    /* This functionality is currently experimental.
      * vtx_t vtx is not implemented and may be used in the future
      * for optimization.
      */

--- a/resource/reapi/bindings/c++/reapi.hpp
+++ b/resource/reapi/bindings/c++/reapi.hpp
@@ -190,6 +190,21 @@ class reapi_t {
         return -1;
     }
 
+    /*! Update the resource state with R.
+     *
+     *  \param h         Opaque handle. How it is used is an implementation
+     *                   detail. However, when it is used within a Flux's
+     *                   service module, it is expected to be a pointer
+     *                   to a flux_t object.
+     *  \param R_subgraph R String of std::string.
+     *  \return          0 on success; -1 on error.
+     */
+    static int grow (void *h,
+                     const std::string &R_subgraph)
+    {
+        return -1;
+    }
+
     /*! Cancel the allocation or reservation corresponding to jobid.
      *
      *  \param h         Opaque handle. How it is used is an implementation

--- a/resource/reapi/bindings/c++/reapi_cli.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli.hpp
@@ -89,6 +89,7 @@ class resource_query_t {
     void set_job (const uint64_t jobid, const std::shared_ptr<job_info_t> &job);
     int remove_job (const uint64_t jobid);
     int remove_job (const uint64_t jobid, const std::string &R, bool &full_removal);
+    int grow (const std::string &R_subgraph);
     void incr_job_counter ();
 
     /* Run the traverser to match the jobspec */
@@ -148,6 +149,7 @@ class reapi_cli_t : public reapi_t {
                                 int64_t &at,
                                 double &ov,
                                 std::string &R_out);
+    static int grow (void *h, const std::string &R_subgraph);
     static int cancel (void *h, const uint64_t jobid, bool noent_ok);
     static int cancel (void *h,
                        const uint64_t jobid,

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -165,6 +165,15 @@ int reapi_cli_t::update_allocate (void *h,
     return NOT_YET_IMPLEMENTED;
 }
 
+int reapi_cli_t::grow (void *h,
+                       const std::string &R_subgraph)
+{
+    resource_query_t *rq = static_cast<resource_query_t *> (h);
+    int rc = -1;
+
+    return rq->grow (std::string (R_subgraph));
+}
+
 int reapi_cli_t::match_allocate_multi (void *h,
                                        bool orelse_reserve,
                                        const char *jobs,
@@ -720,6 +729,26 @@ int resource_query_t::remove_job (const uint64_t jobid, const std::string &R, bo
     }
 
     return rc;
+}
+
+int resource_query_t::grow (const std::string &R_subgraph)
+{
+    int rc = -1;
+    std::shared_ptr<resource_reader_base_t> reader;
+    vtx_t v = boost::graph_traits<resource_graph_t>::null_vertex ();
+
+    if (R_subgraph == "") {
+        errno = EINVAL;
+        return rc;
+    }
+    if ((reader = create_resource_reader ("jgf")) == nullptr) {
+        m_err_msg = __FUNCTION__;
+        m_err_msg += ": ERROR: can't create JGF reader\n";
+        return rc;
+    }
+
+
+    return reader->unpack_at (db->resource_graph, db->metadata, v, R_subgraph, -1);
 }
 
 void resource_query_t::incr_job_counter ()

--- a/resource/reapi/bindings/c/reapi_cli.cpp
+++ b/resource/reapi/bindings/c/reapi_cli.cpp
@@ -186,6 +186,21 @@ out:
     return rc;
 }
 
+extern "C" int reapi_cli_grow (reapi_cli_ctx_t *ctx,
+                               const char *R_subgraph)
+{
+    int rc = -1;
+    if (!ctx || !ctx->rqt || !R_subgraph) {
+        errno = EINVAL;
+        goto out;
+    }
+    if ((rc = reapi_cli_t::grow (ctx->rqt, R_subgraph)) < 0) {
+        goto out;
+    }
+out:
+    return rc;
+}
+
 extern "C" int reapi_cli_cancel (reapi_cli_ctx_t *ctx, const uint64_t jobid, bool noent_ok)
 {
     if (!ctx || !ctx->rqt) {

--- a/resource/reapi/bindings/c/reapi_cli.cpp
+++ b/resource/reapi/bindings/c/reapi_cli.cpp
@@ -273,13 +273,8 @@ extern "C" int reapi_cli_stat (reapi_cli_ctx_t *ctx,
 extern "C" const char *reapi_cli_get_err_msg (reapi_cli_ctx_t *ctx)
 {
     std::string err_buf = "";
-
-    if (ctx->rqt)
-        err_buf = ctx->rqt->get_resource_query_err_msg () + reapi_cli_t::get_err_message ()
+    err_buf = ctx->rqt->get_resource_query_err_msg () + reapi_cli_t::get_err_message ()
                   + ctx->err_msg;
-    else
-        err_buf = reapi_cli_t::get_err_message () + ctx->err_msg;
-
     return strdup (err_buf.c_str ());
 }
 

--- a/resource/reapi/bindings/c/reapi_cli.h
+++ b/resource/reapi/bindings/c/reapi_cli.h
@@ -140,6 +140,18 @@ int reapi_cli_update_allocate (reapi_cli_ctx_t *ctx,
                                double *ov,
                                const char **R_out);
 
+/*! Update the resource state with R.
+    *
+    *  \param h         Opaque handle. How it is used is an implementation
+    *                   detail. However, when it is used within a Flux's
+    *                   service module, it is expected to be a pointer
+    *                   to a flux_t object.
+    *  \param R_subgraph R String
+    *  \return          0 on success; -1 on error.
+    */
+int reapi_cli_grow (reapi_cli_ctx_t *ctx,
+                    const char *R_subgraph);
+
 /*! Cancel the allocation or reservation corresponding to jobid.
  *
  *  \param ctx       reapi_cli_ctx_t context object

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -535,6 +535,8 @@ int dfu_impl_t::mod_plan (vtx_t u, int64_t jobid, modify_data_t &mod_data)
         span = alloc_span->second;
         if (mod_data.mod_type != job_modify_t::PARTIAL_CANCEL) {
             (*m_graph)[u].schedule.allocations.erase (alloc_span);
+        } else {
+            goto done;
         }
     } else if ((res_span = (*m_graph)[u].schedule.reservations.find (jobid))
                != (*m_graph)[u].schedule.reservations.end ()) {


### PR DESCRIPTION
This is the bug that is preventing us from seeing the full error messages, which are present! I don't know the logic of `ctx->rqt` but the check is preventing us from calling `ctx->rqt->get_resource_query_err_msg ()`, which is where the error messages we aren't seeing are being stored. 

If [get_resource_query_err_msg](https://github.com/flux-framework/flux-sched/blob/93589f5379c2580c8ee1f1c6d46014752bfcfcd7/resource/reapi/bindings/c%2B%2B/reapi_cli_impl.hpp#L588) is just returning that field on the class (an [empty string](https://github.com/flux-framework/flux-sched/blob/93589f5379c2580c8ee1f1c6d46014752bfcfcd7/resource/reapi/bindings/c%2B%2B/reapi_cli_impl.hpp#L45)) is there harm in just calling it? Unless it's done like that because it could be a null pointer? In that case, it seems like the check we are doing is off, because we want the error messages. I don't have a good suggestion to fix it.

Anyway - this is great! I can now see what it's fussing about and continue working / debugging fluxion-go!

```console
Error in ReapiClient Grow: issue resource api client grow -1 grow: ERROR: reader returned error: unpack_edge: source and/or target vertex not found1 -> 100.

grow: ERROR: grow error: Invalid argument
```
I knew it was some dumb user error I made... :fire:  :laughing: 
