### PR TITLE
reapi: expose shrink (remove_subgraph)

### DIFF
--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -1298,10 +1298,7 @@ int resource_reader_jgf_t::unpack_at (resource_graph_t &g,
                                       const std::string &str,
                                       int rank)
 {
-    /* This functionality is currently experimental, as resource graph
-     * growth causes a resize of the boost vecS vertex container type.
-     * Resizing the vecS results in lost job allocations and reservations
-     * as there is no copy constructor for planner.
+    /* This functionality is currently experimental.
      * vtx_t vtx is not implemented and may be used in the future
      * for optimization.
      */

--- a/resource/reapi/bindings/c++/reapi.hpp
+++ b/resource/reapi/bindings/c++/reapi.hpp
@@ -190,7 +190,7 @@ class reapi_t {
         return -1;
     }
 
-    /*! Update the resource state with R.
+    /*! Update the resource state (grow) with R.
      *
      *  \param h         Opaque handle. How it is used is an implementation
      *                   detail. However, when it is used within a Flux's
@@ -201,6 +201,21 @@ class reapi_t {
      */
     static int grow (void *h,
                      const std::string &R_subgraph)
+    {
+        return -1;
+    }
+
+    /*! Update the resource state (shink) with R node path.
+     *
+     *  \param h           Opaque handle. How it is used is an implementation
+     *                     detail. However, when it is used within a Flux's
+     *                     service module, it is expected to be a pointer
+     *                     to a flux_t object.
+     *  \param R_node_path String of node path in graph std::string.
+     *  \return            0 on success; -1 on error.
+     */
+    static int shrink (void *h,
+                       const std::string &R_subgraph)
     {
         return -1;
     }

--- a/resource/reapi/bindings/c++/reapi.hpp
+++ b/resource/reapi/bindings/c++/reapi.hpp
@@ -190,6 +190,21 @@ class reapi_t {
         return -1;
     }
 
+    /*! Update the resource state with R.
+     *
+     *  \param h         Opaque handle. How it is used is an implementation
+     *                   detail. However, when it is used within a Flux's
+     *                   service module, it is expected to be a pointer
+     *                   to a flux_t object.
+     *  \param R_subgraph R String of std::string.
+     *  \return          0 on success; -1 on error.
+     */
+    static int grow (void *h,
+                     const std::string &R_subgraph)
+    {
+        return -1;
+    }
+
     /*! Cancel the allocation or reservation corresponding to jobid.
      *
      *  \param h         Opaque handle. How it is used is an implementation

--- a/resource/reapi/bindings/c++/reapi_cli.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli.hpp
@@ -90,6 +90,7 @@ class resource_query_t {
     int remove_job (const uint64_t jobid);
     int remove_job (const uint64_t jobid, const std::string &R, bool &full_removal);
     int grow (const std::string &R_subgraph);
+    int shrink (const std::string &R_node_path);
     void incr_job_counter ();
 
     /* Run the traverser to match the jobspec */
@@ -150,6 +151,7 @@ class reapi_cli_t : public reapi_t {
                                 double &ov,
                                 std::string &R_out);
     static int grow (void *h, const std::string &R_subgraph);
+    static int shrink (void *h, const std::string &R_node_path);
     static int cancel (void *h, const uint64_t jobid, bool noent_ok);
     static int cancel (void *h,
                        const uint64_t jobid,

--- a/resource/reapi/bindings/c++/reapi_cli.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli.hpp
@@ -89,6 +89,7 @@ class resource_query_t {
     void set_job (const uint64_t jobid, const std::shared_ptr<job_info_t> &job);
     int remove_job (const uint64_t jobid);
     int remove_job (const uint64_t jobid, const std::string &R, bool &full_removal);
+    int grow (const std::string &R_subgraph);
     void incr_job_counter ();
 
     /* Run the traverser to match the jobspec */
@@ -148,6 +149,7 @@ class reapi_cli_t : public reapi_t {
                                 int64_t &at,
                                 double &ov,
                                 std::string &R_out);
+    static int grow (void *h, const std::string &R_subgraph);
     static int cancel (void *h, const uint64_t jobid, bool noent_ok);
     static int cancel (void *h,
                        const uint64_t jobid,

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -165,6 +165,15 @@ int reapi_cli_t::update_allocate (void *h,
     return NOT_YET_IMPLEMENTED;
 }
 
+int reapi_cli_t::grow (void *h,
+                       const std::string &R_subgraph)
+{
+    resource_query_t *rq = static_cast<resource_query_t *> (h);
+    int rc = -1;
+
+    return rq->grow (std::string (R_subgraph));
+}
+
 int reapi_cli_t::match_allocate_multi (void *h,
                                        bool orelse_reserve,
                                        const char *jobs,
@@ -720,6 +729,26 @@ int resource_query_t::remove_job (const uint64_t jobid, const std::string &R, bo
     }
 
     return rc;
+}
+
+int resource_query_t::grow (const std::string &R_subgraph)
+{
+    int rc = -1;
+    std::shared_ptr<resource_reader_base_t> reader;
+    vtx_t v = boost::graph_traits<resource_graph_t>::null_vertex ();
+
+    if (R_subgraph == "") {
+        errno = EINVAL;
+        return rc;
+    }
+    if ((reader = create_resource_reader ("jgf")) == nullptr) {
+        m_err_msg = __FUNCTION__;
+        m_err_msg += ": ERROR: can't create JGF reader\n";
+        return rc;
+    }
+
+
+    return reader->unpack_at (db->resource_graph, db->metadata, v, R_subgraph, -1);
 }
 
 void resource_query_t::incr_job_counter ()

--- a/resource/reapi/bindings/c/reapi_cli.cpp
+++ b/resource/reapi/bindings/c/reapi_cli.cpp
@@ -201,6 +201,21 @@ out:
     return rc;
 }
 
+extern "C" int reapi_cli_shrink (reapi_cli_ctx_t *ctx,
+                                 const char *R_node_path)
+{
+    int rc = -1;
+    if (!ctx || !ctx->rqt || !R_node_path) {
+        errno = EINVAL;
+        goto out;
+    }
+    if ((rc = reapi_cli_t::shrink (ctx->rqt, R_node_path)) < 0) {
+        goto out;
+    }
+out:
+    return rc;
+}
+
 extern "C" int reapi_cli_cancel (reapi_cli_ctx_t *ctx, const uint64_t jobid, bool noent_ok)
 {
     if (!ctx || !ctx->rqt) {

--- a/resource/reapi/bindings/c/reapi_cli.cpp
+++ b/resource/reapi/bindings/c/reapi_cli.cpp
@@ -186,6 +186,21 @@ out:
     return rc;
 }
 
+extern "C" int reapi_cli_grow (reapi_cli_ctx_t *ctx,
+                               const char *R_subgraph)
+{
+    int rc = -1;
+    if (!ctx || !ctx->rqt || !R_subgraph) {
+        errno = EINVAL;
+        goto out;
+    }
+    if ((rc = reapi_cli_t::grow (ctx->rqt, R_subgraph)) < 0) {
+        goto out;
+    }
+out:
+    return rc;
+}
+
 extern "C" int reapi_cli_cancel (reapi_cli_ctx_t *ctx, const uint64_t jobid, bool noent_ok)
 {
     if (!ctx || !ctx->rqt) {

--- a/resource/reapi/bindings/c/reapi_cli.h
+++ b/resource/reapi/bindings/c/reapi_cli.h
@@ -152,6 +152,18 @@ int reapi_cli_update_allocate (reapi_cli_ctx_t *ctx,
 int reapi_cli_grow (reapi_cli_ctx_t *ctx,
                     const char *R_subgraph);
 
+/*! Update the resource state (shrink) with R node path.
+    *
+    *  \param h           Opaque handle. How it is used is an implementation
+    *                     detail. However, when it is used within a Flux's
+    *                     service module, it is expected to be a pointer
+    *                     to a flux_t object.
+    *  \param R_node_path String of node path in graph std::string.
+    *  \return            0 on success; -1 on error.
+    */
+int reapi_cli_shrink (reapi_cli_ctx_t *ctx,
+                      const char *R_subgraph);
+
 /*! Cancel the allocation or reservation corresponding to jobid.
  *
  *  \param ctx       reapi_cli_ctx_t context object

--- a/resource/reapi/bindings/c/reapi_cli.h
+++ b/resource/reapi/bindings/c/reapi_cli.h
@@ -140,6 +140,18 @@ int reapi_cli_update_allocate (reapi_cli_ctx_t *ctx,
                                double *ov,
                                const char **R_out);
 
+/*! Update the resource state with R.
+    *
+    *  \param h         Opaque handle. How it is used is an implementation
+    *                   detail. However, when it is used within a Flux's
+    *                   service module, it is expected to be a pointer
+    *                   to a flux_t object.
+    *  \param R_subgraph R String
+    *  \return          0 on success; -1 on error.
+    */
+int reapi_cli_grow (reapi_cli_ctx_t *ctx,
+                    const char *R_subgraph);
+
 /*! Cancel the allocation or reservation corresponding to jobid.
  *
  *  \param ctx       reapi_cli_ctx_t context object

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -535,6 +535,8 @@ int dfu_impl_t::mod_plan (vtx_t u, int64_t jobid, modify_data_t &mod_data)
         span = alloc_span->second;
         if (mod_data.mod_type != job_modify_t::PARTIAL_CANCEL) {
             (*m_graph)[u].schedule.allocations.erase (alloc_span);
+        } else {
+            goto done;
         }
     } else if ((res_span = (*m_graph)[u].schedule.reservations.find (jobid))
                != (*m_graph)[u].schedule.reservations.end ()) {


### PR DESCRIPTION
Problem: a full elasticity implementation for the go bindings (and other bindings) requires an ability to shrink. I think that this function is implemented (remove_subgraph in the reapi implementation c++ seems to do it, and very simply by providing a path?) but not exposed.
Solution: expose the function via a corresponding "shrink" API call. 

### Points I thought about

- I don't know if this accounts for proper cancel of jobs on those resources (and other needed cleanup), but should suffice for testing of the endpoint. In our various Go/Kubernetes implementations we likely wouldn't make this call until some nodes are actually going away, so the assumption would be they are not running jobs.
- The operation (and function name) are called `remove_subgraph`, and while that's more accurate to describe the operation, I like having the API expose "shrink" because it matches grow (which also has a different underlying call, `unpack_at`) and will be easy for the developer to understand / relate to one another.
- This does not include #8, and thankfully I didn't need it because it worked the first time! But this fix is important to expose errors - I just didn't want to tangle the PRs.

The corresponding Go PR is here: https://github.com/flux-framework/fluxion-go/pull/13 with a simple test that calls shrink to remove one node, and then tries to run the grow jobspec again (which requires 4) and this time it should fail (and it does). Unlike the first PR, I updated the testing and builds there to use my branch here so you can see the operations:

![image](https://github.com/user-attachments/assets/c6fa2fe3-ed33-4603-a546-4ee63250a5fb)
